### PR TITLE
Support for HTML templates

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Install dependencies
-        run: pip install pandas
+        run: pip install pandas jinja2
       - name: Generate html pages
         run: python src/generate_website.py
       - name: Upload artifact

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -1,0 +1,15 @@
+<html>
+  <head>
+     <title>{{ title }}</title>
+     <description>PCC Bibframe Interoperability Group (BIG) DCTap-to-SHACL</description>
+     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+  </head>
+  <body class="container">
+    <h1>{{ title }}</h1> 
+    {% block body %}{% endblock %}
+    <footer>
+     Version {{ version }}.  
+     Github Repository <a href="https://github.com/bf-interop/DCTap/">https://github.com/bf-interop/DCTap/</a>
+    </footer>
+  </body>
+</html>

--- a/src/templates/dctap.html
+++ b/src/templates/dctap.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+
+{% block body %}
+{{ dctap_table|safe }}
+{% endblock %}

--- a/src/templates/dctap_index.html
+++ b/src/templates/dctap_index.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+
+
+{% block body %}
+<ul>
+{% for file in dctap_dirs %}
+  <li><a href="{{ file.url }}">{{ file.name }}</a></li>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+
+
+{% block body %}
+<ul>
+{% for file in dctap_dirs %}
+  <li><a href="{{ file.url }}">{{ file.name }}</a></li>
+{% endfor %}
+</ul>
+{% endblock %}


### PR DESCRIPTION
Uses [jinja2](https://jinja.palletsprojects.com/en/stable/) templates for the following pages:

- Home page `index.html` - Edit this template to change content for the DCTap [home page](https://bf-interop.github.io/DCTap/)
- Inner index page `dctap_index.html` - Example [Monograph DCTAP](https://bf-interop.github.io/DCTap/Monograph_DCTAP/)
- Individual CSV Pages `dctap.html` - Example [Monograph Instance Electronic DCTap](https://bf-interop.github.io/DCTap/Monograph_DCTAP/Monograph_Instance_Electronic.html)